### PR TITLE
Fix c_char type error (i8 vs u8) when building on linux arm64

### DIFF
--- a/core/src/connection.rs
+++ b/core/src/connection.rs
@@ -16,7 +16,7 @@ pub struct Connection {
     pub(crate) connection: std::sync::Arc<std::sync::Mutex<libpq::Connection>>,
 }
 
-extern "C" fn notice_processor(_arg: *mut std::ffi::c_void, message: *const i8) {
+extern "C" fn notice_processor(_arg: *mut std::ffi::c_void, message: *const std::ffi::c_char) {
     let message = unsafe { std::ffi::CStr::from_ptr(message) };
 
     log::info!("{}", message.to_str().unwrap().trim());


### PR DESCRIPTION
Commit fixes following error when building on linux arm64 (Ubuntu in Docker on Apple M1):

```
error[E0308]: mismatched types
  --> /home/[redacted]/.cargo/registry/src/github.com-1ecc6299db9ec823/elephantry-3.0.0/src/connection.rs:41:50
   |
41 |             connection.set_notice_processor(Some(notice_processor), std::ptr::null_mut());
   |                                             ---- ^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
   |                                             |
   |                                             arguments to this enum variant are incorrect
   |
   = note: expected fn pointer `unsafe extern "C" fn(_, *const u8)`
                 found fn item `extern "C" fn(_, *const i8) {notice_processor}`
```

Relevant links:
- https://github.com/rust-lang/rust/issues/60226
- https://github.com/sportsball-ai/blackmagic-raw-rs/pull/3/files