### PR TITLE
Main

### DIFF
--- a/core/src/from_sql.rs
+++ b/core/src/from_sql.rs
@@ -1,5 +1,6 @@
 use byteorder::ReadBytesExt;
 
+#[doc(hidden)]
 #[inline]
 pub fn not_null<T>(raw: Option<T>) -> crate::Result<T> {
     raw.ok_or(crate::Error::NotNull)

--- a/core/src/from_sql.rs
+++ b/core/src/from_sql.rs
@@ -1,7 +1,7 @@
 use byteorder::ReadBytesExt;
 
 #[inline]
-pub(crate) fn not_null<T>(raw: Option<T>) -> crate::Result<T> {
+pub fn not_null<T>(raw: Option<T>) -> crate::Result<T> {
     raw.ok_or(crate::Error::NotNull)
 }
 

--- a/derive/src/enum.rs
+++ b/derive/src/enum.rs
@@ -62,7 +62,7 @@ pub(crate) fn impl_macro(ast: &syn::DeriveInput) -> syn::Result<proc_macro2::Tok
                     oid: 0,
                     descr: stringify!(#name),
                     name: stringify!(#name),
-                    kind: libpq::types::Kind::Enum,
+                    kind: #elephantry::pq::types::Kind::Enum,
                 }
             }
 


### PR DESCRIPTION
Fix the macro derive "Enum" as it seems to be broken due to the access level of "not_null" limited to crate. Also replacing the use of Kind inside the macro from external libpq crate by the one re-exported by elephantry.